### PR TITLE
Add new action to copy the pass-name

### DIFF
--- a/helm-pass.el
+++ b/helm-pass.el
@@ -76,7 +76,8 @@ Does not clear it from clipboard."
   '(("Copy password to clipboard" . password-store-copy)
     ("Copy username to clipboard" . helm-pass-get-username)
     ("Edit entry" . password-store-edit)
-    ("Browse url of entry" . password-store-url))
+    ("Browse url of entry" . password-store-url)
+    ("Copy pass-name to clipboard" . kill-new))
   "List of actions for `helm-pass'."
   :group 'helm-pass
   :type '(alist :key-type string :value-type function))


### PR DESCRIPTION
I would rather call it the pass path, but the official documentation of pass calls it [pass-name](https://git.zx2c4.com/password-store/about/).